### PR TITLE
fix #17: Forces Travis to build Master and Develop branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 sudo: false
+branches:
+  only:
+    - master
+    - develop
 language: ruby
 rvm:
   - 2.3.0


### PR DESCRIPTION
There's a small problem with the Travis build: it's not building the master branch once it's merged. This should fix it, forcing the push to build only the master and develop branches.